### PR TITLE
Add @package to the docs

### DIFF
--- a/can-event-dom-radiochange.js
+++ b/can-event-dom-radiochange.js
@@ -110,6 +110,7 @@ function removeListener (eventName, el) {
 /**
  * @module {events} can-event-dom-radiochange
  * @parent can-infrastructure
+ * @package ./package.json
  *
  * A custom event for listening to changes of inputs with type "radio",
  * which fires when a conflicting radio input changes. A "conflicting"


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.