### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/can-event-dom-radiochange.js
+++ b/can-event-dom-radiochange.js
@@ -2,7 +2,7 @@
 
 var events = require('can-util/dom/events/events');
 var domData = require('can-util/dom/data/data');
-var getDocument = require('can-util/dom/document/document');
+var getDocument = require('can-globals/document/document');
 var domEvents = require('can-dom-events');
 var CIDMap = require('can-util/js/cid-map/cid-map');
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "can-dom-events": "^1.0.2",
-    "can-util": "^3.8.4"
+    "can-util": "^3.8.4",
+    "can-globals": "^0.1.0"
   },
   "devDependencies": {
     "fixpack": "^2.3.1",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.